### PR TITLE
Allow passing in environment when starting

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,43 +5,35 @@
 ;;;
 ;;; SPDX-License-Identifier: AGPL-3.0-or-later
 
-{:deps {org.bdinetwork/service-provider-authentication {:git/url "https://github.com/Basic-Data-Infrastructure/service-provider-authentication.git"
-                                                        :git/sha "e43ab92fb044ca742b4e2a32ae7a378abc3eb2fc"}
-
-        org.bdinetwork/clj-ishare-client {:git/url "https://github.com/Basic-Data-Infrastructure/clj-ishare-client.git"
-                                          :git/sha "fdaa77a9f5326b99a6e402de6f4083a0d29c334f"}
-
-        org.bdinetwork/clj-ishare-jwt {:git/url "https://github.com/Basic-Data-Infrastructure/clj-ishare-jwt.git"
-                                       :git/sha "f7590e16c50e2a274c9307bd3be21ef179f9dce5"}
-
-        compojure/compojure              {:mvn/version "1.7.1"}
-        hiccup/hiccup                    {:mvn/version "2.0.0-RC3"}
-        ring/ring-core                   {:mvn/version "1.12.2"}
-        ring/ring-defaults               {:mvn/version "0.5.0"}
-        ring/ring-jetty-adapter          {:mvn/version "1.12.2"}
-        ring/ring-devel                  {:mvn/version "1.12.2"}
-        ring/ring-json                   {:mvn/version "0.5.1"}
-        org.clojure/data.json            {:mvn/version "2.5.0"}
-        clj-commons/clj-yaml             {:mvn/version "1.0.27"}
-        org.babashka/http-client         {:mvn/version "0.4.19"}
-        org.babashka/json                {:mvn/version "0.1.6"}
-        buddy/buddy-sign                 {:mvn/version "3.6.1-359"}
-        ch.qos.logback/logback-classic   {:mvn/version "1.5.6"}
-        org.clojure/tools.logging        {:mvn/version "1.3.0"}
-        nl.jomco/ring-session-ttl-memory {:git/url "https://git.sr.ht/~jomco/ring-session-ttl-memory"
-                                          :git/sha "0415dedace39e2d28b6dc66fcf1321e8e136ca2c"}
-        nl.jomco/clj-http-status-codes   {:mvn/version "0.1"}
-
+{:deps {buddy/buddy-sign                                    {:mvn/version "3.6.1-359"}
+        ch.qos.logback/logback-classic                      {:mvn/version "1.5.6"}
+        clj-commons/clj-yaml                                {:mvn/version "1.0.27"}
+        compojure/compojure                                 {:mvn/version "1.7.1"}
+        environ/environ                                     {:mvn/version "1.2.0"}
+        hiccup/hiccup                                       {:mvn/version "2.0.0-RC3"}
+        nl.jomco/clj-http-status-codes                      {:mvn/version "0.1"}
+        nl.jomco/envopts                                    {:mvn/version "0.0.5"}
+        nl.jomco/ring-session-ttl-memory                    {:git/url "https://git.sr.ht/~jomco/ring-session-ttl-memory" :git/sha "0415dedace39e2d28b6dc66fcf1321e8e136ca2c"}
+        org.babashka/http-client                            {:mvn/version "0.4.19"}
+        org.babashka/json                                   {:mvn/version "0.1.6"}
+        org.bdinetwork/clj-ishare-client                    {:git/url "https://github.com/Basic-Data-Infrastructure/clj-ishare-client.git" :git/sha "fdaa77a9f5326b99a6e402de6f4083a0d29c334f"}
+        org.bdinetwork/clj-ishare-jwt                       {:git/url "https://github.com/Basic-Data-Infrastructure/clj-ishare-jwt.git" :git/sha "f7590e16c50e2a274c9307bd3be21ef179f9dce5"}
+        org.bdinetwork/service-provider-authentication      {:git/url "https://github.com/Basic-Data-Infrastructure/service-provider-authentication.git" :git/sha "e43ab92fb044ca742b4e2a32ae7a378abc3eb2fc"}
+        org.clojure/data.json                               {:mvn/version "2.5.0"}
+        org.clojure/tools.logging                           {:mvn/version "1.3.0"}
         ring-basic-authentication/ring-basic-authentication {:mvn/version "1.2.0"}
+        ring/ring-core                                      {:mvn/version "1.12.2"}
+        ring/ring-defaults                                  {:mvn/version "0.5.0"}
+        ring/ring-devel                                     {:mvn/version "1.12.2"}
+        ring/ring-jetty-adapter                             {:mvn/version "1.12.2"}
+        ring/ring-json                                      {:mvn/version "0.5.1"}
 
         ;; for tests
         org.clojure/core.async {:mvn/version "1.6.681"}
         ring/ring-mock         {:mvn/version "0.4.0"}
 
         ;; for uberjar
-        org.clojure/clojure {:mvn/version "1.11.3"}
-        nl.jomco/envopts {:mvn/version "0.0.5"}
-        environ/environ {:mvn/version "1.2.0"}}
+        org.clojure/clojure {:mvn/version "1.11.3"}}
 
  :paths ["src" "resources" "dev" "classes" "test"]
 

--- a/deps.edn
+++ b/deps.edn
@@ -39,7 +39,9 @@
         ring/ring-mock         {:mvn/version "0.4.0"}
 
         ;; for uberjar
-        org.clojure/clojure {:mvn/version "1.11.3"}}
+        org.clojure/clojure {:mvn/version "1.11.3"}
+        nl.jomco/envopts {:mvn/version "0.0.5"}
+        environ/environ {:mvn/version "1.2.0"}}
 
  :paths ["src" "resources" "dev" "classes" "test"]
 


### PR DESCRIPTION
This allows us to tweak the configuration while re-using as much as possible of the normal startup code path. Useful for integration tests where we want to start multiple services in the same JVM.